### PR TITLE
feat: add routine prototype

### DIFF
--- a/src/features/new/presentation/screens/NewScreen.tsx
+++ b/src/features/new/presentation/screens/NewScreen.tsx
@@ -27,8 +27,8 @@ export function NewScreen() {
           </TouchableOpacity>
         </View>
 
-        <Text style={styles.sectionLabel}>ROUTINE NAME</Text>
-        <View style={styles.card}>
+        <View style={styles.routineCard}>
+          <Text style={styles.routineCardLabel}>ROUTINE NAME</Text>
           <TextInput
             defaultValue="Quick abs"
             placeholder="Routine name"
@@ -142,11 +142,27 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     marginBottom: 22,
   },
+  routineCard: {
+    backgroundColor: '#E7E7E7',
+    borderRadius: 26,
+    paddingHorizontal: 20,
+    paddingTop: 20,
+    paddingBottom: 24,
+    marginBottom: 24,
+  },
+  routineCardLabel: {
+    fontSize: 13,
+    fontWeight: '400',
+    color: '#8F8F8F',
+    letterSpacing: 0.3,
+    marginBottom: -26,
+  },
   routineInput: {
-    fontSize: 43,
+    fontSize: 24,
     fontWeight: '700',
-    color: '#171717',
-    paddingVertical: 6,
+    color: '#121212',
+    lineHeight: 56,
+    paddingVertical: 0,
   },
   structureRow: {
     flexDirection: 'row',

--- a/src/features/new/presentation/screens/NewScreen.tsx
+++ b/src/features/new/presentation/screens/NewScreen.tsx
@@ -10,7 +10,7 @@ import {
   View,
 } from 'react-native';
 
-const HEADER_ACTION_SIZE = 28;
+const HEADER_ACTION_SIZE = 32;
 
 
 export function NewScreen() {
@@ -94,13 +94,13 @@ const styles = StyleSheet.create({
   },
   content: {
     paddingHorizontal: 20,
-    paddingTop: 14,
+    paddingTop: 24,
     paddingBottom: 160,
   },
   headerRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginBottom: 22,
+    marginBottom: 32,
   },
   headerBackButton: {
     width: 90,
@@ -108,14 +108,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 6,
   },
-  headerAction: {
-    fontSize: 16,
-    color: '#222',
-  },
   headerTitle: {
     flex: 1,
     textAlign: 'center',
-    fontSize: 24,
+    fontSize: 20,
     fontWeight: '700',
     color: '#171717',
   },
@@ -124,15 +120,15 @@ const styles = StyleSheet.create({
     alignItems: 'flex-end',
   },
   headerSave: {
-    fontSize: 24,
+    fontSize: 20,
     fontWeight: '600',
     color: '#7363FF',
   },
   sectionLabel: {
-    fontSize: 29,
+    fontSize: 18,
     fontWeight: '700',
     color: '#9A9A9A',
-    marginBottom: 10,
+    marginBottom: 16,
     letterSpacing: 0.2,
   },
   card: {
@@ -148,7 +144,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingTop: 20,
     paddingBottom: 24,
-    marginBottom: 24,
+    marginBottom: 32,
   },
   routineCardLabel: {
     fontSize: 13,
@@ -171,20 +167,20 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
   },
   structureLabel: {
-    fontSize: 36,
+    fontSize: 18,
     color: '#212121',
   },
   structureValueWrap: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 14,
+    gap: 16,
   },
   operator: {
     fontSize: 36,
     color: '#232323',
   },
   structureValue: {
-    fontSize: 36,
+    fontSize: 24,
     fontWeight: '700',
     color: '#161616',
     minWidth: 50,
@@ -200,7 +196,7 @@ const styles = StyleSheet.create({
   },
   plusText: {
     color: '#FFF',
-    fontSize: 22,
+    fontSize: 24,
     fontWeight: '700',
     marginTop: -2,
   },
@@ -211,7 +207,7 @@ const styles = StyleSheet.create({
   exerciseArtWrap: {
     borderWidth: 2,
     borderColor: '#2692E8',
-    marginBottom: 20,
+    marginBottom: 48,
   },
   exerciseArt: {
     backgroundColor: '#F0F0F0',
@@ -232,11 +228,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     height: 64,
-    marginBottom: 12,
+    marginBottom: 24,
     backgroundColor: '#F8F8F8',
   },
   addBtnText: {
-    fontSize: 34,
+    fontSize: 18,
     color: '#1E1E1E',
   },
   startBtn: {
@@ -245,10 +241,10 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     height: 64,
-    marginBottom: 8,
+    marginBottom: 24,
   },
   startBtnText: {
-    fontSize: 31,
+    fontSize: 18,
     color: '#FFF',
     fontWeight: '500',
   },
@@ -260,7 +256,7 @@ const styles = StyleSheet.create({
     height: 64,
   },
   saveRoutineBtnText: {
-    fontSize: 31,
+    fontSize: 18,
     color: '#FFF',
     fontWeight: '500',
   },

--- a/src/features/new/presentation/screens/NewScreen.tsx
+++ b/src/features/new/presentation/screens/NewScreen.tsx
@@ -1,26 +1,251 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
-import type { RouteProp } from '@react-navigation/native';
+import { Ionicons } from '@expo/vector-icons';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from 'react-native';
 
-import type { TabParamList } from '../../../../navigation/types';
+const HEADER_ACTION_SIZE = 28;
 
-type NewScreenRouteProp = RouteProp<TabParamList, 'New'>;
 
-type NewScreenProps = {
-  route: NewScreenRouteProp;
-};
-
-export function NewScreen({ route }: NewScreenProps) {
-  const label = route.params?.label ?? 'New';
-
+export function NewScreen() {
   return (
-    <View style={styles.container}>
-      <Text style={styles.label}>{label}</Text>
-    </View>
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.headerRow}>
+          <TouchableOpacity activeOpacity={0.8} style={styles.headerBackButton}>
+            <Ionicons name="arrow-back-circle" size={HEADER_ACTION_SIZE} color="#222" />
+          </TouchableOpacity>
+          <Text style={styles.headerTitle}>New Routine</Text>
+          <TouchableOpacity activeOpacity={0.8} style={styles.headerSaveButton}>
+            <Text style={styles.headerSave}>Save</Text>
+          </TouchableOpacity>
+        </View>
+
+        <Text style={styles.sectionLabel}>ROUTINE NAME</Text>
+        <View style={styles.card}>
+          <TextInput
+            defaultValue="Quick abs"
+            placeholder="Routine name"
+            placeholderTextColor="#9B9B9B"
+            style={styles.routineInput}
+          />
+        </View>
+
+        <Text style={styles.sectionLabel}>CIRCUIT STRUCTURE</Text>
+        <View style={styles.card}>
+          <View style={styles.structureRow}>
+            <Text style={styles.structureLabel}>Rounds</Text>
+            <View style={styles.structureValueWrap}>
+              <Text style={styles.operator}>-</Text>
+              <Text style={styles.structureValue}>1</Text>
+              <TouchableOpacity activeOpacity={0.8} style={styles.plusBtn}>
+                <Text style={styles.plusText}>+</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+
+          <View style={styles.separator} />
+
+          <View style={styles.structureRow}>
+            <Text style={styles.structureLabel}>Rest between rounds</Text>
+            <View style={styles.structureValueWrap}>
+              <Text style={styles.operator}>-</Text>
+              <Text style={styles.structureValue}>20s</Text>
+              <TouchableOpacity activeOpacity={0.8} style={styles.plusBtn}>
+                <Text style={styles.plusText}>+</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+
+        <Text style={styles.sectionLabel}>EXERCISES</Text>
+        <View style={styles.exerciseArtWrap}>
+          <View style={styles.exerciseArt}>
+            <Text style={styles.exerciseArtText}>Exercise Preview</Text>
+          </View>
+        </View>
+
+        <TouchableOpacity activeOpacity={0.85} style={styles.addBtn}>
+          <Text style={styles.addBtnText}>+ Add Excercise</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity activeOpacity={0.85} style={styles.startBtn}>
+          <Text style={styles.startBtnText}>START</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity activeOpacity={0.85} style={styles.saveRoutineBtn}>
+          <Text style={styles.saveRoutineBtnText}>SAVE ROUTINE</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#fff' },
-  label: { fontSize: 28, fontWeight: '600', color: '#111' },
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#F4F4F4',
+  },
+  content: {
+    paddingHorizontal: 20,
+    paddingTop: 14,
+    paddingBottom: 160,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 22,
+  },
+  headerBackButton: {
+    width: 90,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+  },
+  headerAction: {
+    fontSize: 16,
+    color: '#222',
+  },
+  headerTitle: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 24,
+    fontWeight: '700',
+    color: '#171717',
+  },
+  headerSaveButton: {
+    width: 90,
+    alignItems: 'flex-end',
+  },
+  headerSave: {
+    fontSize: 24,
+    fontWeight: '600',
+    color: '#7363FF',
+  },
+  sectionLabel: {
+    fontSize: 29,
+    fontWeight: '700',
+    color: '#9A9A9A',
+    marginBottom: 10,
+    letterSpacing: 0.2,
+  },
+  card: {
+    backgroundColor: '#E7E7E7',
+    borderRadius: 18,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    marginBottom: 22,
+  },
+  routineInput: {
+    fontSize: 43,
+    fontWeight: '700',
+    color: '#171717',
+    paddingVertical: 6,
+  },
+  structureRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 8,
+  },
+  structureLabel: {
+    fontSize: 36,
+    color: '#212121',
+  },
+  structureValueWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+  },
+  operator: {
+    fontSize: 36,
+    color: '#232323',
+  },
+  structureValue: {
+    fontSize: 36,
+    fontWeight: '700',
+    color: '#161616',
+    minWidth: 50,
+    textAlign: 'right',
+  },
+  plusBtn: {
+    backgroundColor: '#8F82EA',
+    width: 34,
+    height: 34,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  plusText: {
+    color: '#FFF',
+    fontSize: 22,
+    fontWeight: '700',
+    marginTop: -2,
+  },
+  separator: {
+    height: 1,
+    backgroundColor: '#D3D3D3',
+  },
+  exerciseArtWrap: {
+    borderWidth: 2,
+    borderColor: '#2692E8',
+    marginBottom: 20,
+  },
+  exerciseArt: {
+    backgroundColor: '#F0F0F0',
+    height: 250,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  exerciseArtText: {
+    color: '#7E7E7E',
+    fontSize: 18,
+    fontWeight: '500',
+  },
+  addBtn: {
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: '#B6B6B6',
+    borderRadius: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 64,
+    marginBottom: 12,
+    backgroundColor: '#F8F8F8',
+  },
+  addBtnText: {
+    fontSize: 34,
+    color: '#1E1E1E',
+  },
+  startBtn: {
+    borderRadius: 16,
+    backgroundColor: '#9386EC',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 64,
+    marginBottom: 8,
+  },
+  startBtnText: {
+    fontSize: 31,
+    color: '#FFF',
+    fontWeight: '500',
+  },
+  saveRoutineBtn: {
+    borderRadius: 16,
+    backgroundColor: '#000',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 64,
+  },
+  saveRoutineBtnText: {
+    fontSize: 31,
+    color: '#FFF',
+    fontWeight: '500',
+  },
 });

--- a/src/features/new/presentation/screens/NewScreen.tsx
+++ b/src/features/new/presentation/screens/NewScreen.tsx
@@ -151,13 +151,13 @@ const styles = StyleSheet.create({
     fontWeight: '400',
     color: '#8F8F8F',
     letterSpacing: 0.3,
-    marginBottom: -26,
+    marginBottom: 12,
   },
   routineInput: {
     fontSize: 24,
     fontWeight: '700',
     color: '#121212',
-    lineHeight: 56,
+    lineHeight: 0,
     paddingVertical: 0,
   },
   structureRow: {

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -19,7 +19,7 @@ import { TabParamList } from './types';
 const Tab = createBottomTabNavigator<TabParamList>();
 
 const BAR_BG_COLOR     = '#FFFFFF';
-const BORDER_WIDTH     = 0.2;
+const BORDER_WIDTH     = 0.4;
 const BAR_BORDER_COLOR = '#606060';
 const ACTIVE_COLOR     = '#F1E5D1'; // cream pill behind focused non-center tab
 const FAB_COLOR        = '#8FA968'; // muted olive for FAB
@@ -29,11 +29,11 @@ const ACTIVE_ICON      = '#3E2D14'; // dark brown icon on cream pill
 const FAB_ICON         = '#FFFFFF'; // icon inside the FAB
 const INACTIVE_ICON    = '#2A2A2A'; // default icon on white bar
 const BAR_HEIGHT       = 70;
-const CIRCLE_SIZE      = 46;
-const FAB_SIZE         = 58;
-const FAB_LIFT         = 18; // how far the FAB sits above the bar's top edge
-const ICON_SIZE        = 22;
-const FAB_ICON_SIZE    = 26;
+const CIRCLE_SIZE      = 52;
+const FAB_SIZE         = 60;
+const FAB_LIFT         = 65; // half of FAB_SIZE keeps the middle button centered on the bar edge
+const ICON_SIZE        = 28;
+const FAB_ICON_SIZE    = 32;
 const CENTER_ROUTE     = 'New';
 
 const FAB_LABELS = ['New', 'Add', 'Create', 'Start', 'Track'];

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -36,8 +36,6 @@ const ICON_SIZE        = 28;
 const FAB_ICON_SIZE    = 32;
 const CENTER_ROUTE     = 'New';
 
-const FAB_LABELS = ['New', 'Add', 'Create', 'Start', 'Track'];
-
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 
 const TAB_ICONS: Record<string, { active: IoniconName; inactive: IoniconName }> = {
@@ -66,14 +64,7 @@ function CustomTabBar({ state, navigation }: BottomTabBarProps) {
   const centerRoute = centerIndex >= 0 ? state.routes[centerIndex] : undefined;
 
   const handleFabPress = () => {
-    // TODO: replace with navigation to a dedicated creation page.
-    const currentRoute = state.routes[state.index];
-    const currentLabel =
-      (currentRoute?.name === CENTER_ROUTE &&
-        (currentRoute.params as { label?: string } | undefined)?.label) ||
-      FAB_LABELS[0];
-    const nextIndex = (FAB_LABELS.indexOf(currentLabel) + 1) % FAB_LABELS.length;
-    navigation.navigate(CENTER_ROUTE, { label: FAB_LABELS[nextIndex] });
+    navigation.navigate(CENTER_ROUTE);
   };
 
   return (

--- a/src/navigation/types.ts
+++ b/src/navigation/types.ts
@@ -1,7 +1,7 @@
 export type TabParamList = {
   Home: undefined;
   History: undefined;
-  New: { label?: string } | undefined;
+  New: undefined;
   Routines: undefined;
   Profile: undefined;
 };


### PR DESCRIPTION
## Description
In this PR, I have added a naive functionality to the "add routine" icon (middle icon) of the bottom nav bar. When clicked, it will redirect the user to create a new routine. What is missing of the "add routine" page:
- Go back button function
- Change routine name
- Save button function
- Change "-" and "+" to icon svg buttons. For now they are hardcoded stylized characters.
- Modify the addition and subtraction of the number of repetitions and sets
- Add an image
- add routine button function
- Start button function
- Save routine button function

Something I have also noticed in this page is that when you scroll down, there is a considerable white gap on the bottom page, which suggest that there is unused space. I will be waiting for further comments and suggestions

## Verification
<img width="800" height="1533" alt="gid" src="https://github.com/user-attachments/assets/fd419dce-85a4-47e9-9847-d4626119adc9" />

## Testing
Manually tested the core feature of transition from add to the new page. All the missing features have been listed to this PR